### PR TITLE
add instructions for including env2 and tls object

### DIFF
--- a/step2.md
+++ b/step2.md
@@ -58,7 +58,7 @@ Hint: `server.connection`
 
 8. Change the `BASE_URL` variable in your `config.env` to `https`, instead of `http`.
 
-9. Push your latest changes to Github....yes the only thing that you have changed is that you added "keys" to your gitignore. But never forget this step :fire:.
+9. Push your latest changes to Github.
 
 If you start your server now, and try to go to `http://localhost:3000`, this won't work. You're on https now :tada:.
 

--- a/step2.md
+++ b/step2.md
@@ -53,9 +53,12 @@ Now you have a third file called `cert.pem`.
 
 6. **Add "keys" to your gitignore**. NEVER PUSH YOUR KEYS TO GITHUB! :scream:
 
-7. Change the `BASE_URL` variable in your `config.env` to `https`, instead of `http`.
+7. Browse through the hapi docs again to find out how to create an HTTPS connection on your server.  
+Hint: `server.connection`
 
-8. Push your latest changes to Github....yes the only thing that you have changed is that you added "keys" to your gitignore. But never forget this step :fire:.
+8. Change the `BASE_URL` variable in your `config.env` to `https`, instead of `http`.
+
+9. Push your latest changes to Github....yes the only thing that you have changed is that you added "keys" to your gitignore. But never forget this step :fire:.
 
 If you start your server now, and try to go to `http://localhost:3000`, this won't work. You're on https now :tada:.
 

--- a/step3.md
+++ b/step3.md
@@ -15,7 +15,8 @@ Swap driver & computer again. But there's no need to raise a new github issue th
   + `Application Name`: Call it what you like (but it generally makes sense for it to be the same name as your repo).  
   + `Homepage url`: type your `BASE_URL` (e.g. `https://localhost:3000` - don't forget the 's' in 'https')  
   + `Application description`: you can leave it blank for this workshop, but you might want to be descriptive when you create an actual project
-  + `Authorization callback url`: type your `BASE_URL` + `/welcome` (e.g. `https://localhost:3000/welcome`)
+  + `Authorization callback url`: type your `BASE_URL` + `/welcome` (e.g. `https://localhost:3000/welcome`)  
+  Note: You want to access your `BASE_URL` from your `config.env` by installing the `env2` module
 
 4. Add 2 new variables to your `config.env`: `CLIENT_ID` and `CLIENT_SECRET`, taken from your app page on Github.  
 Remember: you need to preface these lines in your `config.env` with "export" (not "export**s**")  


### PR DESCRIPTION
+ add another bullet point to step 2, instructing students to look at the `server.connection` docs for how to create an HTTPS connection
+ add a note to step 3, reminding students to get the `BASE_URL` from their `config.env`, and instructing them to install `env2` for this

@mattlub Please merge this & close the issue if you're happy with the changes?

Relates #1 