### PR TITLE
specify: only 1 required parameter for the login handler

### DIFF
--- a/step4.md
+++ b/step4.md
@@ -15,7 +15,7 @@ It is up to the user to look through the list of permissions, and consent / not 
 + Fill in the handler for this route:
   + Find out the Github url that your app needs to query, by looking in the docs of the 3rd party application that you're using  
   [Here are the Github API docs again](https://developer.github.com/v3/oauth/#web-application-flow)  
-  Note: You only _need_ to pass in 2 of the parameters: the `client_id` & `redirect_uri`
+  Note: The only parameter you _need_ to pass is the `client_id`, but check out the optional parameters that you have too.
   + You will need to use hapi's [`reply.redirect`](https://hapijs.com/api#replyredirecturi) method
 
 + Test your route with [`server.inject`](https://hapijs.com/api#serverinjectoptions-callback)


### PR DESCRIPTION
+ Remove suggestion that `redirect_uri` is required
+ Direct students to docs again - [`scope` is a good one to know about](https://developer.github.com/v3/oauth/#parameters)

Fixes #7 - @oliverjam please review but @lucyrose93 is the one who is "assigned". Only she should merge this, as the "fixes" keyword will close her issue automatically :+1: 